### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,0 +1,13 @@
+{
+    "name": "aiplatform",
+    "name_pretty": "AI Platform",
+    "product_documentation": "https://cloud.google.com/ai-platform",
+    "client_documentation": "http://cloud.google.com/python/docs/reference/aiplatform/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559744",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_COMBO",
+    "repo": "googleapis/python-aiplatform",
+    "distribution_name": "google-cloud-aiplatform",
+    "api_id": "aiplatform.googleapis.com"
+}


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.